### PR TITLE
identify users by idp guid

### DIFF
--- a/search-api/migrations/versions/3faf50891480_index_by_idp_guid.py
+++ b/search-api/migrations/versions/3faf50891480_index_by_idp_guid.py
@@ -1,0 +1,26 @@
+"""index-by-idp-guid
+
+Revision ID: 3faf50891480
+Revises: f7d39c77458f
+Create Date: 2022-12-13 11:30:36.659379
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3faf50891480'
+down_revision = 'f7d39c77458f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_user_idp_userid'), 'users', ['idp_userid'], unique=True)
+    op.create_unique_constraint('users_idp_userid_key', 'users', ['idp_userid'])
+
+
+def downgrade():
+    op.drop_index(op.f('ix_user_idp_userid'), table_name='users')
+    op.drop_constraint('users_idp_userid_key', 'users', ['idp_userid'])

--- a/search-api/src/search_api/models/user.py
+++ b/search-api/src/search_api/models/user.py
@@ -51,6 +51,7 @@ class User(db.Model):
     lastname = db.Column(db.String(1000))
     email = db.Column(db.String(1024))
     login_source = db.Column('login_source', db.String(200), nullable=True)
+    idp_userid = db.Column(db.String(256), index=True)
     sub = db.Column(db.String(36), unique=True)
     iss = db.Column(db.String(1024))
     creation_date = db.Column(db.DateTime(timezone=True), default=datetime.utcnow)
@@ -85,7 +86,7 @@ class User(db.Model):
     @classmethod
     def find_by_jwt_token(cls, token: dict):
         """Return a User if they exist and match the provided JWT."""
-        return cls.query.filter_by(sub=token['sub']).one_or_none()
+        return cls.query.filter_by(idp_userid=token['idp_userid']).one_or_none()
 
     @classmethod
     def create_from_jwt_token(cls, token: dict):
@@ -110,6 +111,7 @@ class User(db.Model):
                 iss=token['iss'],
                 sub=token['sub'],
                 login_source=token['loginSource'],
+                idp_userid=token['idp_userid'],
             )
             current_app.logger.debug('Creating user from JWT:{}; User:{}'.format(token, user))
             db.session.add(user)

--- a/search-api/tests/unit/api/businesses/test_document_request.py
+++ b/search-api/tests/unit/api/businesses/test_document_request.py
@@ -147,7 +147,7 @@ def test_post_business_document(session, client, jwt, mocker):
     mocker.patch('search_api.services.validator.RequestValidator.validate_document_access_request',
                  return_value=[])
     mocker.patch('search_api.resources.v1.businesses.documents.document_request.get_role', return_value='basic')
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     mocker.patch('search_api.models.User.get_or_create_user_by_jwt', return_value=user)
     mock_response = MockResponse({'id': 123}, HTTPStatus.CREATED)
     mocker.patch('search_api.request_handlers.document_access_request_handler.create_payment',
@@ -178,7 +178,7 @@ def test_post_business_document_payment_failure(session, client, jwt, mocker):
     mocker.patch('search_api.services.validator.RequestValidator.validate_document_access_request',
                  return_value=[])
     mocker.patch('search_api.resources.v1.businesses.documents.document_request.get_role', return_value='basic')
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     mocker.patch('search_api.models.User.get_or_create_user_by_jwt', return_value=user)
     mock_response = MockResponse({'id': 123}, HTTPStatus.BAD_REQUEST)
     mocker.patch('search_api.request_handlers.document_access_request_handler.create_payment',
@@ -215,7 +215,7 @@ def create_document_access_request(identifier: str, account_id: int, is_paid: bo
         document_access_request.payment_completion_date=datetime.utcnow()
         document_access_request.status=DocumentAccessRequest.Status.PAID.value
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document = Document(document_type=DocumentType.LETTER_UNDER_SEAL.value, document_key='test')

--- a/search-api/tests/unit/api/businesses/test_document_request.py
+++ b/search-api/tests/unit/api/businesses/test_document_request.py
@@ -252,6 +252,7 @@ def test_post_business_document_submit_ce_to_queue(ld, session, client, jwt, moc
     firstname = 'firstname'
     lastname = 'lastname'
     sub = 'this-is-the-key'
+    idp_userid = '123'
     iss = 'iss'
     login_source = 'API_GW'
  
@@ -270,6 +271,7 @@ def test_post_business_document_submit_ce_to_queue(ld, session, client, jwt, moc
                           'sub': sub,
                           'iss': iss,
                           'login_source': login_source,
+                          'idp_userid': idp_userid,
                           })
     user.save()
     mocker.patch('search_api.models.User.get_or_create_user_by_jwt',
@@ -307,6 +309,7 @@ def test_post_business_document_submit_ce_to_queue(ld, session, client, jwt, moc
                                                      lastname=lastname,
                                                      login_source=login_source,
                                                      sub=sub,
+                                                     idp_userid=idp_userid,
                                                      **{'Accept-Version': 'v1',
                                                         'Account-Id': account_id,
                                                         'content-type': 'application/json'

--- a/search-api/tests/unit/api/test_purchase_requests.py
+++ b/search-api/tests/unit/api/test_purchase_requests.py
@@ -77,7 +77,7 @@ def create_document_access_request(identifier: str, account_id: int, is_paid: bo
         document_access_request.payment_completion_date=datetime.utcnow()
         document_access_request.status=DocumentAccessRequest.Status.PAID.value
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document = Document(document_type=DocumentType.LETTER_UNDER_SEAL.value, document_key='test')

--- a/search-api/tests/unit/models/test_document_access_request.py
+++ b/search-api/tests/unit/models/test_document_access_request.py
@@ -31,7 +31,7 @@ def test_document_request_save(session):
         expiry_date = datetime.now()+ relativedelta(days=7)
     )
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document = Document(document_type=DocumentType.LETTER_UNDER_SEAL.value, document_key='test')
@@ -54,7 +54,7 @@ def test_find_active_requests(session):
         status=DocumentAccessRequest.Status.PAID.value
     )
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document_1 = Document(document_type=DocumentType.LETTER_UNDER_SEAL.value, document_key='test1')
@@ -82,7 +82,7 @@ def test_find_by_id(session):
         expiry_date=datetime.now() + relativedelta(days=7)
     )
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document = Document(document_type=DocumentType.LETTER_UNDER_SEAL.value, document_key='test')
@@ -109,7 +109,7 @@ def test_document_access_request_json(session):
         status=DocumentAccessRequest.Status.PAID.value
     )
 
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     document_access_request.submitter = user
 
     document_1 = Document(document_type=DocumentType.LETTER_UNDER_SEAL, document_key='test1')

--- a/search-api/tests/unit/models/test_user.py
+++ b/search-api/tests/unit/models/test_user.py
@@ -23,7 +23,7 @@ from search_api.models import User
 
 def test_user(session):
     """Assert that a User can be stored in the service."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
 
     session.add(user)
     session.commit()
@@ -33,11 +33,11 @@ def test_user(session):
 
 def test_user_find_by_jwt_token(session):
     """Assert that a User can be stored in the service."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     session.add(user)
     session.commit()
 
-    token = {'sub': 'sub'}
+    token = {'idp_userid': '123'}
     u = User.find_by_jwt_token(token)
 
     assert u.id is not None
@@ -51,6 +51,7 @@ def test_create_from_jwt_token(session):
              'iss': 'iss',
              'sub': 'sub',
              'loginSource': 'test',
+             'idp_userid': '123',
              }
     u = User.create_from_jwt_token(token)
     assert u.id is not None
@@ -64,6 +65,7 @@ def test_get_or_create_user_by_jwt(session):
              'iss': 'iss',
              'sub': 'sub',
              'loginSource': 'test',
+             'idp_userid': '123',
              }
     u = User.get_or_create_user_by_jwt(token)
     assert u.id is not None
@@ -80,6 +82,7 @@ def test_get_or_create_user_by_jwt_existing(session):
              'iss': 'iss',
              'sub': 'sub',
              'loginSource': 'test',
+             'idp_userid': '123',
              }
     u = User.get_or_create_user_by_jwt(token)
 
@@ -99,6 +102,7 @@ def test_get_or_create_user_by_jwt_existing(session):
                      'iss': 'iss',
                      'sub': 'sub',
                      'loginSource': 'test',
+                     'idp_userid': '123',
                      }
 
     new = User.get_or_create_user_by_jwt(updated_token)
@@ -137,7 +141,7 @@ def test_create_from_invalid_jwt_token(session):
 
 def test_find_by_username(session):
     """Assert User can be found by the most current username."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     session.add(user)
     session.commit()
 
@@ -148,7 +152,7 @@ def test_find_by_username(session):
 
 def test_find_by_sub(session):
     """Assert find User by the unique sub key."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     session.add(user)
     session.commit()
 
@@ -159,7 +163,7 @@ def test_find_by_sub(session):
 
 def test_user_save(session):
     """Assert User record is saved."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     user.save()
 
     assert user.id is not None
@@ -167,7 +171,7 @@ def test_user_save(session):
 
 def test_user_delete(session):
     """Assert the User record is deleted."""
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     user.save()
     user.delete()
 
@@ -190,6 +194,6 @@ TEST_USER_DISPLAY_NAME = [
 @pytest.mark.parametrize('test_description, username, firstname, lastname, display_name', TEST_USER_DISPLAY_NAME)
 def test_user_display_name(session, test_description, username, firstname, lastname, display_name):
     """Assert the User record returns the expected display name."""
-    user = User(username=username, firstname=firstname, lastname=lastname, sub='sub', iss='iss')
+    user = User(username=username, firstname=firstname, lastname=lastname, sub='sub', iss='iss', idp_userid='123')
 
     assert display_name == user.display_name

--- a/search-api/tests/unit/request_handlers/test_document_access_request_handler.py
+++ b/search-api/tests/unit/request_handlers/test_document_access_request_handler.py
@@ -36,7 +36,7 @@ DOCUMENT_ACCESS_REQUEST_TEMPLATE = {
 def test_save_request(client, session, jwt, mocker):
     """Assert that request can be saved."""
     g.jwt_oidc_token_info={}
-    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss')
+    user = User(username='username', firstname='firstname', lastname='lastname', sub='sub', iss='iss', idp_userid='123')
     user.save()
     mocker.patch('search_api.models.User.get_or_create_user_by_jwt', return_value=user)
     document_access_request = save_request(1, 1, DOCUMENT_ACCESS_REQUEST_TEMPLATE)

--- a/search-api/tests/unit/services/document_services/test_simple_cloudevent.py
+++ b/search-api/tests/unit/services/document_services/test_simple_cloudevent.py
@@ -101,7 +101,7 @@ def test_create_doc_request_ce(client, session, set_env, jwt, mocker):
         #     'time': time,
         # }
         g.jwt_oidc_token_info={}
-        user = User(username='username', firstname='firstname', lastname='lastname', sub=user_sub, iss='iss')
+        user = User(username='username', firstname='firstname', lastname='lastname', sub=user_sub, iss='iss', idp_userid='123')
         user.save()
         mocker.patch('search_api.models.User.get_or_create_user_by_jwt', return_value=user)
         document_access_request = save_request(1, 1, DOCUMENT_ACCESS_REQUEST_TEMPLATE)

--- a/search-api/tests/unit/services/utils.py
+++ b/search-api/tests/unit/services/utils.py
@@ -26,6 +26,7 @@ def helper_create_jwt(jwt_manager,
                       lastname: str = None,
                       login_source:str = None,
                       sub:str = None,
+                      idp_userid: str = None,
                       ):
     """Create a jwt bearer token with the correct keys, roles and username."""
     token_header = {
@@ -46,6 +47,7 @@ def helper_create_jwt(jwt_manager,
         'lastname': lastname,
         'email': email,
         'loginSource': login_source,
+        'idp_userid': idp_userid,
         'realm_access': {
             'roles': [] + roles
         }
@@ -61,6 +63,7 @@ def create_header(jwt_manager,
                   email: str = None,
                   login_source:str = None,
                   sub:str = '43e6a245-0bf7-4ccf-9bd0-e7fb85fd18cc',
+                  idp_userid: str = '123',
                   **kwargs):
     """Return a header containing a JWT bearer token."""
     token = helper_create_jwt(jwt_manager,
@@ -70,6 +73,7 @@ def create_header(jwt_manager,
                               lastname=lastname,
                               email=email,
                               login_source=login_source,
+                              idp_userid=idp_userid,
                               sub=sub,
                               )
     headers = {**kwargs, **{'Authorization': 'Bearer ' + token}}


### PR DESCRIPTION
Issue #, if available:
bcgov/entity#14596

Description of changes:
after keycloak migration to gold, sub from jwt token (i.e. keycloak guid) will be changed for users, as it is tied to a specific IDP instance, and idp guid should be used instead to uniquely identify users

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
