### PR TITLE
UI - cleanup ldarkly flag used in search release

### DIFF
--- a/search-ui/package.json
+++ b/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-ui",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/search-ui/src/router/router.ts
+++ b/search-ui/src/router/router.ts
@@ -8,18 +8,17 @@ import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 // Local
 import { RouteNames } from '@/enums'
 import { SearchBusinessInfoBreadcrumb } from '@/resources'
-import { getFeatureFlag, navigate } from '@/utils'
-import { routes, routes_old } from './routes'
+import { navigate } from '@/utils'
+import { routes } from './routes'
 
 export function createVueRouter(): Router {
-  
   const router = createRouter({
     history: createWebHistory(sessionStorage.getItem('VUE_ROUTER_BASE') || ''),
-    routes: getFeatureFlag('search-moved') ? routes : routes_old
+    routes: routes
   })
 
   router.beforeEach(async (to, _from, next) => {
-    if (to.name === RouteNames.SEARCH && getFeatureFlag('search-moved')) {
+    if (to.name === RouteNames.SEARCH) {
       const bpSearchUrl = sessionStorage.getItem('BP_SEARCH_URL')
       // The identifier and documentAccessRequestId params cause it to load and then go to other pages
       if (bpSearchUrl && !to.query.identifier && !to.query.documentAccessRequestId) {
@@ -69,23 +68,23 @@ export function createVueRouter(): Router {
       }
     })
   })
-  
+
   /** Returns True if route requires authentication, else False. */
   function requiresAuth(route: RouteLocationNormalized): boolean {
     return route.matched.some(r => r.meta?.requiresAuth)
   }
-  
+
   /** Returns True if user is authenticated, else False. */
   function isAuthenticated(): boolean {
     // FUTURE: also check that token isn't expired!
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
   }
-  
+
   /** Returns True if route is Login success, else False. */
   function isLogin(route: RouteLocationNormalized): boolean {
     return Boolean(route.name === RouteNames.LOGIN)
   }
-  
+
   /** Returns True if route is Login success, else False. */
   function isLoginSuccess(route: RouteLocationNormalized): boolean {
     return Boolean(route.name === RouteNames.LOGIN && route.hash)

--- a/search-ui/src/router/routes.ts
+++ b/search-ui/src/router/routes.ts
@@ -10,9 +10,9 @@ import {
   Signout
  } from '@/views'
 import { RouteNames } from '@/enums'
-import { SearchBreadcrumb, SearchDashboardBreadcrumb, SearchHomeBreadCrumb } from '@/resources'
+import { SearchBreadcrumb, SearchHomeBreadCrumb } from '@/resources'
 
-export const routes_old: RouteRecordRaw[] = [
+export const routes: RouteRecordRaw[] = [
   {
     // router.beforeEach() routes here:
     path: '/login',
@@ -50,7 +50,7 @@ export const routes_old: RouteRecordRaw[] = [
     component: DashboardView,
     meta: {
       requiresAuth: false, // landing page so needs chance to load without auth
-      breadcrumb:[SearchHomeBreadCrumb, SearchDashboardBreadcrumb]
+      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
     },
   },
   {
@@ -60,16 +60,16 @@ export const routes_old: RouteRecordRaw[] = [
     props: true,
     meta: {
       requiresAuth: false, // app.vue will still verify token after page init
-      breadcrumb:[SearchHomeBreadCrumb, SearchDashboardBreadcrumb]
+      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
     },
   },
   {
     path: '/open/request',
     name: RouteNames.DOCUMENT_REQUEST,
-    component: DocumentRequestView,    
+    component: DocumentRequestView,
     meta: {
       requiresAuth: true,
-      breadcrumb:[SearchHomeBreadCrumb, SearchDashboardBreadcrumb]
+      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
     },
   },
   {
@@ -78,39 +78,4 @@ export const routes_old: RouteRecordRaw[] = [
     path: '/:pathMatch(.*)*',
     redirect: '/'
   }
-]
-
-export const routes: RouteRecordRaw[] = [
-  routes_old[0],
-  routes_old[1],
-  routes_old[2],
-  {
-    path: '/',
-    name: RouteNames.SEARCH,
-    component: DashboardView,
-    meta: {
-      requiresAuth: false, // landing page so needs chance to load without auth
-      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
-    },
-  },
-  {
-    path: '/open/:identifier',
-    name: RouteNames.BUSINESS_INFO,
-    component: BusinessInfoView,
-    props: true,
-    meta: {
-      requiresAuth: false, // app.vue will still verify token after page init
-      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
-    },
-  },
-  {
-    path: '/open/request',
-    name: RouteNames.DOCUMENT_REQUEST,
-    component: DocumentRequestView,    
-    meta: {
-      requiresAuth: true,
-      breadcrumb:[SearchHomeBreadCrumb, SearchBreadcrumb]
-    },
-  },
-  routes_old[6],
 ]

--- a/search-ui/src/utils/launchdarkly.ts
+++ b/search-ui/src/utils/launchdarkly.ts
@@ -6,8 +6,7 @@ import { initialize, LDClient, LDFlagSet, LDOptions, LDUser } from 'launchdarkly
 const defaultFlagSet: LDFlagSet = {
   'ui-enabled': false,
   'banner-text': ' ',
-  'sentry-enable': false,
-  'search-moved': false,
+  'sentry-enable': false
 }
 
 /**

--- a/search-ui/tests/unit/App.spec.ts
+++ b/search-ui/tests/unit/App.spec.ts
@@ -11,7 +11,7 @@ import { SbcHeader, SbcFooter } from '@/sbc-common-components'
 // import vuetify from '@/plugins/vuetify'
 import { useAuth, useDocumentAccessRequest, useEntity } from '@/composables'
 import { ErrorCategories, ErrorCodes, ProductCode, ProductStatus, RouteNames } from '@/enums'
-import { SearchBusinessInfoBreadcrumb, SearchDashboardBreadcrumb, SearchHomeBreadCrumb } from '@/resources'
+import { SearchBusinessInfoBreadcrumb, SearchBreadcrumb, SearchHomeBreadCrumb } from '@/resources'
 import { DefaultError, EntityLoadError, PayDefaultError } from '@/resources/error-dialog-options'
 import { createVueRouter } from '@/router'
 import store from '@/store'
@@ -84,10 +84,10 @@ describe('App tests', () => {
     expect(wrapper.findComponent(SbcFooter).exists()).toBe(true)
   })
   it('passes correct breadcrumbs depending on route', async () => {
-    const expectedSearchBreadcrumbs = [SearchHomeBreadCrumb, SearchDashboardBreadcrumb]
+    const expectedSearchBreadcrumbs = [SearchHomeBreadCrumb, SearchBreadcrumb]
     const identifier = 'BC1234567'
     const businessInfoCrumb = { text: identifier, to: SearchBusinessInfoBreadcrumb.to }
-    const expectedBusinessInfoBreadcrumbs = [SearchHomeBreadCrumb, SearchDashboardBreadcrumb, businessInfoCrumb]
+    const expectedBusinessInfoBreadcrumbs = [SearchHomeBreadCrumb, SearchBreadcrumb, businessInfoCrumb]
     // currently on search route
     expect(router.currentRoute.value.name).toBe(RouteNames.SEARCH)
     expect(wrapper.findComponent(BcrsBreadcrumb).props().breadcrumbs).toEqual(expectedSearchBreadcrumbs)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26483

*Description of changes:*
- remove 'search-moved' flag check; always redirect users to the new search

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the PPR license (Apache 2.0).
