### PR TITLE
chore: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/search-ui-cd.yml
+++ b/.github/workflows/search-ui-cd.yml
@@ -30,7 +30,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-cd.yaml@main
     with:
       target: ${{ inputs.environment }}
-      node_version: "18.16.0"
+      node_version: "24"
       app_name: "registries-search-ui"
       working_directory: "search-ui"
       redeploy: ${{ inputs.redeploy }}

--- a/.github/workflows/search-ui-ci.yml
+++ b/.github/workflows/search-ui-ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v4

--- a/search-ui/package.json
+++ b/search-ui/package.json
@@ -2,6 +2,9 @@
   "name": "search-ui",
   "version": "2.1.14",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835

*Description of changes:*
Update engines field in package.json to require Node.js >= 24.
Update GitHub Actions CI/CD workflows to use Node 24.
Align with modern runtime standards and ensure pipeline stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
